### PR TITLE
[SOS-458] show path field by default instead of program

### DIFF
--- a/bin/esgrep
+++ b/bin/esgrep
@@ -152,7 +152,7 @@ else:
                 msg = '{0} {1} {2} {3}'.format(
                         doc['_source']['@timestamp'],
                         doc['_source']['host'],
-                        doc['_source']['program'],
+                        doc['_source']['path'],
                         doc['_source']['message']
                        )
             print(msg)


### PR DESCRIPTION
tested this on moose-kibana01:

```
[14:46][root@moose-kibana01 twells]$ ./esgrep 'host:sip2-102.nexcess.net' -ts 'now-1m' | head
2018-11-02T18:46:08.214Z sip2-102.nexcess.net /var/log/cron 2018-11-02T14:46:01.966819-04:00 sip2-102.nexcess.net CROND[27988]: (root) CMD ([ -x /usr/lib64/sa/sa1 ] && exec /usr/lib64/sa/sa1 -S ALL 119 1)
2018-11-02T18:46:22.160Z sip2-102.nexcess.net /var/log/messages 2018-11-02T14:46:21.772492-04:00 sip2-102.nexcess.net clamd[4766]: SelfCheck: Database status OK.
2018-11-02T18:46:23.813Z sip2-102.nexcess.net /var/log/smtp/current @400000005bdc9b8636839ac4 tcpserver: status: 0/50
2018-11-02T18:46:23.813Z sip2-102.nexcess.net /var/log/smtp/current @400000005bdc9b86141a1864 rblsmtpd: 81.45.175.104 pid 28437: 451 https://www.spamhaus.org/query/ip/81.45.175.104
2018-11-02T18:46:23.813Z sip2-102.nexcess.net /var/log/smtp/current @400000005bdc9b860c66473c tcpserver: pid 28437 from 81.45.175.104
2018-11-02T18:46:23.813Z sip2-102.nexcess.net /var/log/smtp/current @400000005bdc9b860c619fd4 tcpserver: status: 1/50
2018-11-02T18:46:23.813Z sip2-102.nexcess.net /var/log/smtp/current @400000005bdc9b86368392f4 tcpserver: end 28437 status 0
2018-11-02T18:46:23.813Z sip2-102.nexcess.net /var/log/smtp/current @400000005bdc9b860c6754c4 tcpserver: ok 28437 sip2-102.nexcess.net:::ffff:192.64.52.201:25 :::ffff:81.45.175.104::34988
2018-11-02T18:46:48.815Z sip2-102.nexcess.net /var/log/smtp/current @400000005bdc9b9f35210554 tcpserver: status: 1/50
2018-11-02T18:46:48.815Z sip2-102.nexcess.net /var/log/smtp/current @400000005bdc9ba012d36f64 tcpserver: end 28632 status 0
```